### PR TITLE
Replacing original weapon range dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ https://docs.google.com/spreadsheets/d/1_6zsM7kzvg0aUT8YtM_-Wg_5K1gKDOlrwfVzutEj
 Weapon perk effects are collected from `The Destiny Data Compendium` spreadsheet:
 https://docs.google.com/spreadsheets/d/1WaxvbLx7UoSZaBqdFr1u32F2uWVLo-CJunJB4nlGUE4/edit#gid=1662574278
 
+
+### Mapping of Weapon Range
+
+See `weapon_range_by_type_v2.json`
+
+Weapon range calculator based upon base data and formulas from this spreadsheet:
+https://docs.google.com/spreadsheets/d/1SR7cVCxkZdKA0GvSVbKcWn17KEv71bKXLXA_jt3fOIU/edit#gid=0
+
+Data is compiled by hand from `The Destiny Data Compendium` spreadsheet:
+https://docs.google.com/spreadsheets/d/1WaxvbLx7UoSZaBqdFr1u32F2uWVLo-CJunJB4nlGUE4/edit#gid=1662574278
+
+
 ### Bootstrap.json
 
 Not for external use.
@@ -28,6 +40,8 @@ The value in this file is incremented when source data in this repository has be
 
 ### Deprecated
 
-`sandbox_perk_info.json`, `perk_details.json` used to provide descriptions of perks.  This is being replaced by [Clarity](https://d2clarity.com).
+`sandbox_perk_info.json`, `perk_details.json`: Used to provide descriptions of perks.  Weapon perk info is now being provided by [Clarity](https://d2clarity.com).
 
 `weapon_reviews.json`:  Replaced by `item_reviews.json`.
+
+`weapon_range_by_type_v2.json`: Did not support perks with multiple tiers of effects and was retired.

--- a/weapon_range_by_type.json
+++ b/weapon_range_by_type.json
@@ -101,7 +101,7 @@
         "isADS": true,
         "isConditional": true,
         "scalar": 1.0,
-        "buff": 20
+        "buff": 30
       }
     ],
     "2450788523": [

--- a/weapon_range_by_type.json
+++ b/weapon_range_by_type.json
@@ -93,12 +93,26 @@
         "isConditional": true,
         "scalar": 1.0,
         "buff": 25
+      },
+      {
+        "name": "Opening Shot",
+        "isADS": false,
+        "isConditional": true,
+        "scalar": 1.0,
+        "buff": 25
       }
     ],
     "1370847713": [
       {
         "name": "Enhanced Opening Shot",
         "isADS": true,
+        "isConditional": true,
+        "scalar": 1.0,
+        "buff": 30
+      },
+      {
+        "name": "Enhanced Opening Shot",
+        "isADS": false,
         "isConditional": true,
         "scalar": 1.0,
         "buff": 30

--- a/weapon_range_by_type_v2.json
+++ b/weapon_range_by_type_v2.json
@@ -87,7 +87,6 @@
     "47981717": [
       {
         "name": "Opening Shot",
-        "fireMode": "ADS",
         "isConditional": true,
         "buffs": [25]
       }
@@ -95,9 +94,8 @@
     "1370847713": [
       {
         "name": "Enhanced Opening Shot",
-        "fireMode": "ADS",
         "isConditional": true,
-        "buffs": [20]
+        "buffs": [30]
       }
     ],
     "2450788523": [

--- a/weapon_range_by_type_v2.json
+++ b/weapon_range_by_type_v2.json
@@ -80,14 +80,14 @@
     "2846385770": [
       {
         "name": "Rangefinder",
-        "isADS": true,
+        "fireMode": "ADS",
         "scalars": [1.1]
       }
     ],
     "47981717": [
       {
         "name": "Opening Shot",
-        "isADS": true,
+        "fireMode": "ADS",
         "isConditional": true,
         "buffs": [25]
       }
@@ -95,7 +95,7 @@
     "1370847713": [
       {
         "name": "Enhanced Opening Shot",
-        "isADS": true,
+        "fireMode": "ADS",
         "isConditional": true,
         "buffs": [20]
       }
@@ -118,7 +118,7 @@
     "1866048759": [
       {
         "name": "Hip-Fire Grip",
-        "isADS": false,
+        "fireMode": "HIP_FIRE",
         "scalars": [1.2]
       }
     ],
@@ -141,7 +141,7 @@
     "2416023159": [
       {
         "name": "Offhand Strike",
-        "isADS": false,
+        "fireMode": "HIP_FIRE",
         "isConditional": true,
         "scalars": [1.45]
       }
@@ -149,7 +149,7 @@
     "3050799639": [
       {
         "name": "Offhand Strike (Enhanced)",
-        "isADS": false,
+        "fireMode": "HIP_FIRE",
         "isConditional": true,
         "scalars": [1.45]
       }

--- a/weapon_range_by_type_v2.json
+++ b/weapon_range_by_type_v2.json
@@ -1,0 +1,186 @@
+{
+  "rangeByWeaponTypeMap": {
+    "5": {
+      "range": {
+        "name": "AutoRifles all",
+        "vpp": 0.0963,
+        "baseRange": 11.8700
+      }
+    },
+    "6": {
+      "range": {
+        "name": "Hand Cannon Default",
+        "vpp": 0.0864,
+        "baseRange": 16.9600
+      },
+      "customizations" : {
+        "2757685314": {
+          "name": "Hand Cannon - Aggressive Frame",
+          "vpp": 0.0900,
+          "baseRange": 20.0000
+        },
+        "3923638944": {
+          "name": "Hand Cannon - Double Fire Frame",
+          "vpp": 0.0900,
+          "baseRange": 20.0000
+        }
+      }
+    },
+    "8": {
+      "range": {
+        "name": "Scout Rifles all",
+        "vpp": 0.1521,
+        "baseRange": 30.8900
+      }
+    },
+    "11": {
+      "range": {
+        "name": "Shotguns all",
+        "vpp": 0.0360,
+        "baseRange": 3.4000
+      }
+    },
+    "14": {
+      "range": {
+        "name": "Sidearms all",
+        "vpp": 0.0306,
+        "baseRange": 11.9400
+      }
+    },
+    "2489664120": {
+      "range": {
+        "name": "Trace Rifles all",
+        "vpp": 0.0900,
+        "baseRange": 16.0000
+      }
+    },
+    "3954685534": {
+      "range": {
+        "name": "SMGs all",
+        "vpp": 0.0891,
+        "baseRange": 8.8300
+      }
+    },
+    "7": {
+      "range": {
+        "name": "Pulse Rifles all",
+        "vpp": 0.0770,
+        "baseRange": 16.8000
+      }
+    },
+    "9": {
+      "range": {
+        "name": "Fusion Rifles all",
+        "vpp": 0.0324,
+        "baseRange": 10.5600
+      }
+    }
+  },
+  "rangeModifiersMap": {
+    "2846385770": [
+      {
+        "name": "Rangefinder",
+        "isADS": true,
+        "scalars": [1.1]
+      }
+    ],
+    "47981717": [
+      {
+        "name": "Opening Shot",
+        "isADS": true,
+        "isConditional": true,
+        "buffs": [25]
+      }
+    ],
+    "1370847713": [
+      {
+        "name": "Enhanced Opening Shot",
+        "isADS": true,
+        "isConditional": true,
+        "buffs": [20]
+      }
+    ],
+    "2450788523": [
+      {
+        "name": "Killing Wind",
+        "isConditional": true,
+        "scalars": [1.05],
+        "buffs": [20]
+      }
+    ],
+    "3161816588": [
+      {
+        "name": "Slideshot",
+        "isConditional": true,
+        "buffs": [20]
+      }
+    ],
+    "1866048759": [
+      {
+        "name": "Hip-Fire Grip",
+        "isADS": false,
+        "scalars": [1.2]
+      }
+    ],
+    "1583705720": [
+      {
+        "name": "Stats for All",
+        "isConditional": true,
+        "scalars": [1.05],
+        "buffs": [10]
+      }
+    ],
+    "1409206216": [
+      {
+        "name": "Stats for All (Enhanced)",
+        "isConditional": true,
+        "scalars": [1.05],
+        "buffs": [10]
+      }
+    ],
+    "2416023159": [
+      {
+        "name": "Offhand Strike",
+        "isADS": false,
+        "isConditional": true,
+        "scalars": [1.45]
+      }
+    ],
+    "3050799639": [
+      {
+        "name": "Offhand Strike (Enhanced)",
+        "isADS": false,
+        "isConditional": true,
+        "scalars": [1.45]
+      }
+    ],
+    "2451262963": [
+      {
+        "name": "Fragile Focus",
+        "isConditional": true,
+        "buffs": [20]
+      }
+    ],
+    "1609056795": [
+      {
+        "name": "Fragile Focus (Enhanced)",
+        "isConditional": true,
+        "buffs": [20]
+      }
+    ],
+    "3907865655": [
+      {
+        "name": "Right Hook",
+        "isConditional": true,
+        "buffs": [20]
+      }
+    ],
+    "2988596335": [
+      {
+        "name": "Alacrity",
+        "isConditional": true,
+        "buffs": [10]
+      }
+    ]
+  }
+}

--- a/weapon_range_by_type_v2.json
+++ b/weapon_range_by_type_v2.json
@@ -179,6 +179,34 @@
         "isConditional": true,
         "buffs": [10]
       }
+    ],
+    "1195158366": [
+      {
+        "name": "Encore",
+        "isConditional": true,
+        "buffs": [5, 10, 15, 20]
+      }
+    ],
+    "838873202": [
+      {
+        "name": "Encore (Enhanced)",
+        "isConditional": true,
+        "buffs": [5, 10, 15, 20]
+      }
+    ],
+    "744594675": [
+      {
+        "name": "Well Rounded",
+        "isConditional": true,
+        "buffs": [10, 20]
+      }
+    ],
+    "2139363611": [
+      {
+        "name": "Well Rounded (Enhanced)",
+        "isConditional": true,
+        "buffs": [10, 20]
+      }
     ]
   }
 }


### PR DESCRIPTION
Original weapon range dataset did not allow for perks with multiple tiers of effects.  It also forced me to specify all fields of a "modifier" and that ended up being uselessly verbose.